### PR TITLE
Added the ability to read textures for the PS2 version of HWVX

### DIFF
--- a/Importer/static_spider.js
+++ b/Importer/static_spider.js
@@ -12,6 +12,8 @@
 
 function get_x_static(selected_game, file_name) {
     offset_mid = undefined
+    count = 0
+    datapack_offset = []
 
     let html = `<div class='sub_file_div'><a class='file_arrow' style='padding-right:6px;padding-left:4px;'>↓</a><a> 🗀 </a> <a id='temp' data-type="x_folder" data-offset="0" class='file_hover_not_selected'>${file_name}</a>`
 
@@ -77,6 +79,7 @@ function get_x_sub_files(offset, index, file_name) {
     }
 
     type = ['car', 'interface', 'item', 'link', 'world', 'colliders', 'world texture', 'geometry', 'share', 'audio', 'music'][u32(offset + 4)]
+    datapack_offset = offset;
 
     let html = ''
 
@@ -91,7 +94,6 @@ function get_x_sub_files(offset, index, file_name) {
 
         number_sounds = u32(temp_offset + 8)
         number_textures = u32(temp_offset + 20)
-
         if (number_sounds == 0 && number_textures == 0) {
             html += `<div style='display: block;' class='sub_file_div'><a class='no_arrow'>↓</a><a> 🗎 </a> <a data-type="x_sub_file" data-offset="${offset}" class='file_hover_not_selected'>${index} ${type}</a></div>`
 
@@ -366,7 +368,7 @@ function get_x_datapack(offset, index) {
 
                 // document.getElementById("texture_row_select_" + i).addEventListener("click", load_edit_texture);
 
-                html += `<div style='display:none' class='sub_file_div'><a class='no_arrow'></a><a> </a> <a data-type="x_texture" data-offset="${texture_offset_list + i_offset}" data-offset_mid="${offset_mid}" class='file_hover_not_selected'>${btf_string}</a></div>`
+                html += `<div style='display:none' class='sub_file_div'><a class='no_arrow'></a><a> </a> <a data-type="x_texture" data-offset_datapack="${offset_datapack}" data-offset="${texture_offset_list + i_offset}" data-offset_mid="${offset_mid}" class='file_hover_not_selected'>${btf_string}</a></div>`
 
             }
 

--- a/Viewer/file_click.js
+++ b/Viewer/file_click.js
@@ -299,7 +299,8 @@ function file_click() {
         load_kart(parseInt(this.dataset.offset), parseInt(this.dataset.mid))
         break
     case "x_texture":
-        load_texture(parseInt(this.dataset.offset), parseInt(this.dataset.offset_mid))
+        console.log(this.dataset);
+        load_texture(parseInt(this.dataset.offset), parseInt(this.dataset.offset_mid), parseInt(this.dataset.offset_datapack))
         break
         load_texture(parseInt(this.dataset.offset), parseInt(this.dataset.offset_mid))
         break


### PR DESCRIPTION
I added support for reading indexed textures for the ps2 version of Hot Wheels Velocity X.

Color lookup tables are stored directly after the texture data in the file format, the offset to the collection of color lookup tables can be found at offset 44 in the datapack. The index of the color table a given texture uses can be found at offset 12 in the texture header. Each CLUT is 1024 bytes.

There is some obfuscation going on to get the right index on the lookup table, which is handled on line 557 in texture.js.

I did test the program with Pac-Man World Rally it doesn't seem like I broke anything.

I included my findings in the documentation, so you should see a PR for that as well.